### PR TITLE
Fix issue: Video plays twice without the loop flag set

### DIFF
--- a/omxplayer-sync
+++ b/omxplayer-sync
@@ -131,7 +131,6 @@ class OMXPlayerSync():
         self.position_master = 0.0
         self.filename_master = ''
         self.process = None
-        self.first_run = True
 
         signal.signal(signal.SIGINT, self.kill_omxplayer_and_exit)
 
@@ -174,10 +173,8 @@ class OMXPlayerSync():
 
         while True:
             self.play_file(self.playlist[self.playlist_index])
-            if not self.first_run and not self.options.loop and self.playlist_index == 0:
+            if not self.options.loop and self.playlist_index == 0:
                 break
-
-            self.first_run = False
 
     def play_file(self, filename):
         if not os.path.isfile(filename):


### PR DESCRIPTION
Fixes #45.

Because of the conditions to break out of the main loop being checked after
the video is played, execution will always loop once.  There are several
possible solutions:

	1: Play the file after checking the loop conditions.  This has the
	risk of possibly not playing the video at all, if the condtions are
	not correct.

	2: Set the "first play" flag to false after playing the file (before
	checking the loop conditions).

Option 2 seems best, because it guarantees that the video file is always
played at least once.  Since the "first play" flag is only ever used here,
it is actually not needed at all.  the most elegant solution to this bug
is simply to remove the flag.